### PR TITLE
Fix deep ocean BoP sub-biomes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ addon.local.gradle.kts
 addon.late.local.gradle
 addon.late.local.gradle.kts
 layout.json
+/.vs

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.9'
 }
 
 

--- a/src/main/java/climateControl/api/ClimateControlSettings.java
+++ b/src/main/java/climateControl/api/ClimateControlSettings.java
@@ -279,7 +279,7 @@ public class ClimateControlSettings extends Settings {
         .booleanSetting(interveneInHighlandsName, false, "impose Climate Control generation on Highlands world types");
 
     public final Mutable<Boolean> noBoPSubBiomes = climateControlCategory
-        .booleanSetting(noBoPSubBiomesName, true, "suppress Bop sub-biome generation");
+        .booleanSetting(noBoPSubBiomesName, false, "suppress Bop sub-biome generation");
 
     public final Mutable<Boolean> interveneInBOPWorlds = climateControlCategory.booleanSetting(
         interveneInBOPName,

--- a/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
+++ b/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
@@ -32,6 +32,11 @@ public class BoPSubBiomeReplacer extends BiomeReplacer {
     public int replacement(int currentBiomeId, IntRandomizer randomizer, int x, int z) {
 
         List<BiomeEntry> currentSubBiomes = BOPBiomeManager.overworldSubBiomes[currentBiomeId];
+
+        if (currentBiomeId == 24) { // maybe make this be toggleable with a setting in future
+            currentSubBiomes = null; // prevents BoP sub-biomes generating in deep ocean
+        }
+
         BOPSubBiome selectedSubBiome = currentSubBiomes != null
             ? (BOPSubBiome) currentSubBiomes.get(randomizer.nextInt(currentSubBiomes.size())).biome
             : null;

--- a/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
+++ b/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
@@ -11,6 +11,8 @@ import java.util.logging.Logger;
 import net.minecraft.world.gen.layer.GenLayer;
 import net.minecraft.world.gen.layer.IntCache;
 
+import climateControl.biomeSettings.BiomeReplacer;
+import climateControl.biomeSettings.BoPSubBiomeReplacer;
 import climateControl.genLayerPack.GenLayerPack;
 import climateControl.generator.BiomeSwapper;
 import climateControl.generator.SubBiomeChooser;
@@ -23,6 +25,7 @@ public class GenLayerSubBiome extends GenLayerPack {
     private GenLayer rivers;
     private final SubBiomeChooser subBiomeChooser;
     private final BiomeSwapper mBiomes;
+    private BiomeReplacer BoPSubBiomeReplacer;
 
     private IntRandomizer randomCallback = new IntRandomizer() {
 
@@ -39,6 +42,15 @@ public class GenLayerSubBiome extends GenLayerPack {
         this.subBiomeChooser = subBiomeChooser;
         this.mBiomes = mBiomes;
         this.initChunkSeed(0, 0);
+        try {
+            if (doBoP) {
+                BoPSubBiomeReplacer = new BoPSubBiomeReplacer(randomCallback);
+                logger.info("Bop set up");
+            }
+        } catch (java.lang.NoClassDefFoundError e) {
+            BoPSubBiomeReplacer = null;
+            logger.info("no bop ");
+        }
     }
 
     /**
@@ -110,9 +122,19 @@ public class GenLayerSubBiome extends GenLayerPack {
                         }
                     }
                 }
+                // now the GenLayerHills stuff is done so run BoP subbiome replacements if it's on
+                if (this.BoPSubBiomeReplacer != null) {
+                    this.initChunkSeed((long) (j1 + par1), (long) (i1 + par2));
+                    int old = aint2[j1 + i1 * par3];
+                    aint2[j1 + i1 * par3] = BoPSubBiomeReplacer
+                        .replacement(aint2[j1 + i1 * par3], randomCallback, j1 + par1, i1 + par2);
+                    if (aint2[j1 + i1 * par3] != old) {
+                        // logger.info("BoP subbiome :"+old + " to "+aint2[j1 + i1 * par3]);
+                    }
+                }
             }
-        }
 
+        }
         taste(aint2, par3 * par4);
         return aint2;
     }


### PR DESCRIPTION
Restores previously removed BoP sub-biome generation
Suppresses BoP sub-biome generation in deep ocean
Changes setting default for "suppress BoP sub-biome generation" to false

Prior to 0.8.2, BoP sub-biomes were generated normally, but large erroneous volcanic/tropics/mangrove landmasses generated in deep ocean, with the only fix being a config setting that disabled BoP sub-biomes entirely. In 0.8.2 the code for generating BoP sub-biomes was removed (though the config setting and surrounding strucutre for said code was left intact). This restores that code, while also adding a change to the BoP biome replacer that prevents the erroneous deep ocean sub-biomes from generating. This allows for BoP sub-biomes to be generated as normal, while still suppressing the deep ocean ones. Also, this changes the config default to allow BoP sub-biomes instead of suppress them.