### PR TITLE
Restore 0.6.x Biomes o' Plenty sub-biome generation

### DIFF
--- a/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
+++ b/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
@@ -32,6 +32,11 @@ public class BoPSubBiomeReplacer extends BiomeReplacer {
     public int replacement(int currentBiomeId, IntRandomizer randomizer, int x, int z) {
 
         List<BiomeEntry> currentSubBiomes = BOPBiomeManager.overworldSubBiomes[currentBiomeId];
+
+        if (currentBiomeId == 24) { // maybe make this be toggleable with a setting in future
+            currentSubBiomes = null; // prevents BoP sub-biomes generating in deep ocean
+        }
+
         BOPSubBiome selectedSubBiome = currentSubBiomes != null
             ? (BOPSubBiome) currentSubBiomes.get(randomizer.nextInt(currentSubBiomes.size())).biome
             : null;

--- a/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
+++ b/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
@@ -11,6 +11,8 @@ import java.util.logging.Logger;
 import net.minecraft.world.gen.layer.GenLayer;
 import net.minecraft.world.gen.layer.IntCache;
 
+import climateControl.biomeSettings.BiomeReplacer;
+import climateControl.biomeSettings.BoPSubBiomeReplacer;
 import climateControl.genLayerPack.GenLayerPack;
 import climateControl.generator.BiomeSwapper;
 import climateControl.generator.SubBiomeChooser;
@@ -23,6 +25,7 @@ public class GenLayerSubBiome extends GenLayerPack {
     private GenLayer rivers;
     private final SubBiomeChooser subBiomeChooser;
     private final BiomeSwapper mBiomes;
+    private BiomeReplacer BoPSubBiomeReplacer;
 
     private IntRandomizer randomCallback = new IntRandomizer() {
 
@@ -39,6 +42,15 @@ public class GenLayerSubBiome extends GenLayerPack {
         this.subBiomeChooser = subBiomeChooser;
         this.mBiomes = mBiomes;
         this.initChunkSeed(0, 0);
+        try {
+            if (doBoP) {
+                BoPSubBiomeReplacer = new BoPSubBiomeReplacer(randomCallback);
+                logger.info("Bop set up");
+            }
+        } catch (java.lang.NoClassDefFoundError e) {
+            BoPSubBiomeReplacer = null;
+            logger.info("no bop ");
+        }
     }
 
     /**
@@ -108,6 +120,16 @@ public class GenLayerSubBiome extends GenLayerPack {
                         } else {
                             aint2[j1 + i1 * par3] = biomeVal;
                         }
+                    }
+                }
+                // now the GenLayerHills stuff is done so run BoP subbiome replacements if it's on
+                if (this.BoPSubBiomeReplacer != null) {
+                    this.initChunkSeed((long) (j1 + par1), (long) (i1 + par2));
+                    int old = aint2[j1 + i1 * par3];
+                    aint2[j1 + i1 * par3] = BoPSubBiomeReplacer
+                        .replacement(aint2[j1 + i1 * par3], randomCallback, j1 + par1, i1 + par2);
+                    if (aint2[j1 + i1 * par3] != old) {
+                        // logger.info("BoP subbiome :"+old + " to "+aint2[j1 + i1 * par3]);
                     }
                 }
             }


### PR DESCRIPTION
This re-adds the 0.6.x code that was removed as a hard fix for the gigantic tropical landmasses, allowing Biomes o' Plenty sub-biomes to generate again (assuming the user enables them in their config).

This also adds a check when generating Biomes o' Plenty sub-biomes to see if the parent biome is deep ocean, in which case it nulls the list of sub-biomes for the biome, preventing the tropical landmasses. This removes the need for the user to manually disable tropics, volcano and mangrove as sub-biomes in the Biomes o' Plenty mod's config files like with 0.6.x.

There is, however, a concern that if a user of a 0.8.4-based version (including our 0.9.x) has BoP sub-biomes enabled in their config, and upgrades to a new version with these changes, they will likely end up seeing some chunk wall issues in any partially-explored biomes that are now able to generate BoP sub-biomes (as per their config). This would probably warrant some kind of warning for anyone intending to upgrade their CC version.