### PR TITLE
Restore 0.6.x Biomes o' Plenty sub-biome generation 2

### DIFF
--- a/src/main/java/climateControl/ClimateControl.java
+++ b/src/main/java/climateControl/ClimateControl.java
@@ -34,6 +34,7 @@ import climateControl.utils.Named;
 import climateControl.utils.PropertyManager;
 import climateControl.utils.TaggedConfigManager;
 import climateControl.utils.Zeno410Logger;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -72,6 +73,8 @@ public class ClimateControl {
 
     private ExternalBiomePackage externalBiomesPackage;
 
+    public static boolean isBoPLoaded;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         addonConfigManager = new TaggedConfigManager("climatecontrol.cfg", "ClimateControl");
@@ -91,7 +94,6 @@ public class ClimateControl {
         config.load();
         // if (this.rescueOldCCMode) defaultSettings.set(config);
         // this.settings = defaultSettings.clone();
-
         setupRegistry();
         newSettings.readFrom(config);
 
@@ -110,6 +112,7 @@ public class ClimateControl {
             event.getSuggestedConfigurationFile());
         config.save();
 
+        isBoPLoaded = Loader.isModLoaded("BiomesOPlenty");
     }
 
     @EventHandler

--- a/src/main/java/climateControl/api/ClimateControlSettings.java
+++ b/src/main/java/climateControl/api/ClimateControlSettings.java
@@ -279,7 +279,7 @@ public class ClimateControlSettings extends Settings {
         .booleanSetting(interveneInHighlandsName, false, "impose Climate Control generation on Highlands world types");
 
     public final Mutable<Boolean> noBoPSubBiomes = climateControlCategory
-        .booleanSetting(noBoPSubBiomesName, true, "suppress Bop sub-biome generation");
+        .booleanSetting(noBoPSubBiomesName, false, "suppress Bop sub-biome generation");
 
     public final Mutable<Boolean> interveneInBOPWorlds = climateControlCategory.booleanSetting(
         interveneInBOPName,
@@ -295,7 +295,7 @@ public class ClimateControlSettings extends Settings {
         .booleanSetting(forceStartContinentName, true, "force small continent near origin");
 
     public final boolean doBoPSubBiomes() {
-        return noBoPSubBiomes.value() == false;
+        return !noBoPSubBiomes.value();
     }
 
     public final Mutable<String> externalBiomeNames = climateControlCategory.stringSetting(

--- a/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
+++ b/src/main/java/climateControl/biomeSettings/BoPSubBiomeReplacer.java
@@ -32,6 +32,11 @@ public class BoPSubBiomeReplacer extends BiomeReplacer {
     public int replacement(int currentBiomeId, IntRandomizer randomizer, int x, int z) {
 
         List<BiomeEntry> currentSubBiomes = BOPBiomeManager.overworldSubBiomes[currentBiomeId];
+
+        if (currentBiomeId == BiomeGenBase.deepOcean.biomeID) {
+            currentSubBiomes = null; // prevents BoP sub-biomes generating in deep ocean
+        }
+
         BOPSubBiome selectedSubBiome = currentSubBiomes != null
             ? (BOPSubBiome) currentSubBiomes.get(randomizer.nextInt(currentSubBiomes.size())).biome
             : null;

--- a/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
+++ b/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
@@ -121,12 +121,8 @@ public class GenLayerSubBiome extends GenLayerPack {
                 // now the GenLayerHills stuff is done so run BoP subbiome replacements if it's on
                 if (this.BoPSubBiomeReplacer != null) {
                     this.initChunkSeed(j1 + par1, i1 + par2);
-                    // int old = aint2[j1 + i1 * par3];
                     aint2[j1 + i1 * par3] = BoPSubBiomeReplacer
                         .replacement(aint2[j1 + i1 * par3], randomCallback, j1 + par1, i1 + par2);
-                    // if (aint2[j1 + i1 * par3] != old) {
-                    // logger.info("BoP subbiome :"+old + " to "+aint2[j1 + i1 * par3]);
-                    // }
                 }
             }
         }

--- a/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
+++ b/src/main/java/climateControl/customGenLayer/GenLayerSubBiome.java
@@ -11,6 +11,9 @@ import java.util.logging.Logger;
 import net.minecraft.world.gen.layer.GenLayer;
 import net.minecraft.world.gen.layer.IntCache;
 
+import climateControl.ClimateControl;
+import climateControl.biomeSettings.BiomeReplacer;
+import climateControl.biomeSettings.BoPSubBiomeReplacer;
 import climateControl.genLayerPack.GenLayerPack;
 import climateControl.generator.BiomeSwapper;
 import climateControl.generator.SubBiomeChooser;
@@ -23,6 +26,8 @@ public class GenLayerSubBiome extends GenLayerPack {
     private GenLayer rivers;
     private final SubBiomeChooser subBiomeChooser;
     private final BiomeSwapper mBiomes;
+
+    private BiomeReplacer BoPSubBiomeReplacer;
 
     private IntRandomizer randomCallback = new IntRandomizer() {
 
@@ -39,6 +44,9 @@ public class GenLayerSubBiome extends GenLayerPack {
         this.subBiomeChooser = subBiomeChooser;
         this.mBiomes = mBiomes;
         this.initChunkSeed(0, 0);
+        if (ClimateControl.isBoPLoaded && doBoP) {
+            BoPSubBiomeReplacer = new BoPSubBiomeReplacer(randomCallback);
+        }
     }
 
     /**
@@ -109,6 +117,16 @@ public class GenLayerSubBiome extends GenLayerPack {
                             aint2[j1 + i1 * par3] = biomeVal;
                         }
                     }
+                }
+                // now the GenLayerHills stuff is done so run BoP subbiome replacements if it's on
+                if (this.BoPSubBiomeReplacer != null) {
+                    this.initChunkSeed(j1 + par1, i1 + par2);
+                    // int old = aint2[j1 + i1 * par3];
+                    aint2[j1 + i1 * par3] = BoPSubBiomeReplacer
+                        .replacement(aint2[j1 + i1 * par3], randomCallback, j1 + par1, i1 + par2);
+                    // if (aint2[j1 + i1 * par3] != old) {
+                    // logger.info("BoP subbiome :"+old + " to "+aint2[j1 + i1 * par3]);
+                    // }
                 }
             }
         }


### PR DESCRIPTION
So, basically, it's the same #7, but with some changes: (I don't know why I wrote all this out, it's obvious from the code, but)



- ClimateControlSettings
   * use `false` by default for noBoPSubBiomes
   * replace `noBoPSubBiomes.value() == false` with `!noBoPSubBiomes.value()`

- BoPSubBiomeReplacer
   * change 24 to `BiomeGenBase.deepOcean.biomeID`

- ClimateControl
   * use `Loader.isModLoaded` instead of try/catch

- GenLayerSubBiome
   * comment out debug lines (don't initialize `int old` and don't check `if (aint2[j1 + i1 * par3] != old` all the time)
   * spotlessApply
   
Tested, works

Closes #7 